### PR TITLE
fix: prevent-client-proxy-connections未开启时不应携带ip参数

### DIFF
--- a/auth-yggd/src/main/kotlin/icu/h2l/login/auth/online/YggdrasilAuthModule.kt
+++ b/auth-yggd/src/main/kotlin/icu/h2l/login/auth/online/YggdrasilAuthModule.kt
@@ -518,7 +518,8 @@ class YggdrasilAuthModule(
             val authRequest = MojangStyleAuthRequest(
                 config = authServerConfig,
                 httpClient = httpClient,
-                gson = gson
+                gson = gson,
+                preventProxy = proxy.configuration.shouldPreventClientProxyConnections()
             )
 
             requests.add(Pair(entryConfig.id, authRequest))

--- a/auth-yggd/src/main/kotlin/icu/h2l/login/auth/online/req/MojangStyleAuthRequest.kt
+++ b/auth-yggd/src/main/kotlin/icu/h2l/login/auth/online/req/MojangStyleAuthRequest.kt
@@ -39,7 +39,8 @@ class MojangStyleAuthRequest(
     private val config: AuthServerConfig,
     private val httpClient: HttpClient,
     private val gson: Gson,
-    private val userAgent: String = "HyperZoneLogin/1.0"
+    private val userAgent: String = "HyperZoneLogin/1.0",
+    private val preventProxy: Boolean = false
 ) : AuthenticationRequest {
 
     override suspend fun authenticate(
@@ -77,7 +78,7 @@ class MojangStyleAuthRequest(
             .replace("{serverId}", escapedServerId)
         
         // 处理IP占位符：如果有IP则替换为&ip=xxx，否则替换为空字符串
-        val ipParam = if (playerIp != null) {
+        val ipParam = if (playerIp != null && preventProxy) {
             val escapedIp = UrlEscapers.urlFormParameterEscaper().escape(playerIp)
             "&ip=$escapedIp"
         } else {


### PR DESCRIPTION
## 变更说明

prevent-client-proxy-connections未开启时不应携带ip参数

## 关联范围

- [ ] `openvc`
- [x] `auth-yggd`
- [ ] `auth-offline`
- [ ] `data-merge`
- [ ] `profile-skin`
- [ ] `api`
- [ ] 文档
- [ ] GitHub 工作流 / 仓库配置

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档更新
- [ ] 构建 / CI 调整
- [ ] 其他

## 测试与验证

请说明你做了哪些验证，例如：

- [x] 已本地构建通过
- [x] 已运行相关测试
- [x] 已验证配置生成 / 加载正常
- [x] 已验证迁移逻辑或命令行为
- [ ] 已更新相关文档

## 兼容性与风险

请说明这次改动是否影响：

- 数据库结构
- 配置文件
- 命令行为
- 模块加载顺序
- 迁移流程
- 现有用户部署

## 其他补充

如有截图、日志、配置示例或后续 TODO，请在此补充。

