### PR TITLE
fix: login protocol + skin profile + change name sync

### DIFF
--- a/api/src/main/kotlin/icu/h2l/api/profile/HyperZoneProfileService.kt
+++ b/api/src/main/kotlin/icu/h2l/api/profile/HyperZoneProfileService.kt
@@ -101,6 +101,24 @@ interface HyperZoneProfileService {
      * 将玩家当前会话已提交的凭证绑定到指定 [profileId]。
      */
     fun bindSubmittedCredentials(player: HyperZonePlayer, profileId: UUID): Profile
+
+    /**
+     * 当玩家在外部认证服务（如 Yggdrasil / Mojang）侧改名后，
+     * 用认证返回的最新名称同步更新已绑定正式 Profile 的名称。
+     *
+     * 仅在外部认证名与已绑定 Profile 名不一致时触发实际更新；
+     * 名称冲突（已被其他 Profile 占用）时返回 false 并保留旧名，避免破坏登录。
+     *
+     * 默认实现返回 false，表示当前服务不支持改名同步；
+     * 真正的实现由 [icu.h2l.login.profile.VelocityHyperZoneProfileService] 提供。
+     *
+     * @param profileId 已绑定的正式档案标识
+     * @param authenticatedName 外部认证返回的最新名称
+     * @return true 表示已同步或本就一致；false 表示同步失败或不受支持
+     */
+    fun syncProfileName(profileId: UUID, authenticatedName: String): Boolean {
+        return false
+    }
 }
 
 /**

--- a/auth-yggd/src/main/kotlin/icu/h2l/login/auth/online/service/YggdrasilCredentialService.kt
+++ b/auth-yggd/src/main/kotlin/icu/h2l/login/auth/online/service/YggdrasilCredentialService.kt
@@ -128,6 +128,13 @@ class YggdrasilCredentialService(
             newName = success.profile.name
         )
 
+        // 同步外部认证改名到正式 Profile（LS / Mojang 侧改名后，Profile 表也需更新）
+        if (!profileService.syncProfileName(profileId, success.profile.name)) {
+            debug(HyperZoneDebugType.YGGDRASIL_AUTH) {
+                "[YggdrasilFlow] Profile $profileId 名称同步到 '${success.profile.name}' 失败（可能名称冲突），保留旧名"
+            }
+        }
+
         return profileId
     }
 

--- a/profile-skin/src/main/kotlin/icu/h2l/login/profile/skin/service/ProfileSkinService.kt
+++ b/profile-skin/src/main/kotlin/icu/h2l/login/profile/skin/service/ProfileSkinService.kt
@@ -319,6 +319,19 @@ class ProfileSkinService(
 
         event.rewritePacket = true
         event.uuid = event.hyperZonePlayer.clientOriginalUUID ?: event.currentUuid
+
+        // 将已缓存的皮肤纹理注入到登录成功包中，确保客户端从登录阶段就获得自身皮肤。
+        // 客户端自身皮肤来自 ServerLoginSuccessPacket 的 GameProfile properties，
+        // 而非 PlayerInfo；若不注入，正版客户端将看不到自身皮肤。
+        val profileId = profileService.getAttachedProfile(event.hyperZonePlayer)?.id ?: return
+        val skinId = profileRepository.findSkinIdByProfileId(profileId) ?: return
+        val cachedTextures = cacheRepository.findBySkinId(skinId)?.textures ?: return
+        val textureProperty = cachedTextures.toPropertyOrNull() ?: return
+
+        val existingProperties = event.properties?.toMutableList() ?: mutableListOf()
+        existingProperties.removeAll { it.name.equals("textures", ignoreCase = true) }
+        existingProperties.add(textureProperty)
+        event.properties = existingProperties
     }
 
     private fun restoreTextures(source: ProfileSkinSource): ProfileSkinTextures {

--- a/velocity/src/main/kotlin/icu/h2l/login/database/DatabaseHelper.kt
+++ b/velocity/src/main/kotlin/icu/h2l/login/database/DatabaseHelper.kt
@@ -27,6 +27,7 @@ import icu.h2l.login.manager.DatabaseManager
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.or
 import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.update
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
@@ -191,6 +192,49 @@ class DatabaseHelper(
             true
         } catch (e: Exception) {
             warn { "创建档案失败: ${e.message}" }
+            false
+        }
+    }
+
+    /**
+     * 同步外部认证改名到正式 Profile。
+     *
+     * 仅用于玩家在 Yggdrasil / Mojang 等外部认证服务侧改名后，
+     * 将认证返回的最新名称同步写入正式 Profile 表。
+     *
+     * - 若 Profile 不存在或名称本就一致，直接返回 true；
+     * - 若新名称已被其他 Profile 占用，返回 false 并保留旧名，避免破坏登录；
+     * - 成功更新后同步刷新三套缓存（id / name / uuid）。
+     *
+     * @param profileId 待同步的正式档案标识
+     * @param newName 外部认证返回的最新名称
+     * @return true 表示已同步或本就一致；false 表示同步失败（如名称冲突）
+     */
+    fun updateProfileName(profileId: UUID, newName: String): Boolean {
+        val existing = getProfile(profileId) ?: return false
+        if (existing.name == newName) {
+            return true
+        }
+
+        val conflicting = getProfileByName(newName)
+        if (conflicting != null && conflicting.id != profileId) {
+            warn { "无法同步 Profile $profileId 名称 '$newName'：名称已被其他 Profile ${conflicting.id} 占用，保留旧名 '${existing.name}'" }
+            return false
+        }
+
+        return try {
+            manager.executeTransaction {
+                profileTable.update({ profileTable.id eq profileId }) {
+                    it[profileTable.name] = newName
+                }
+            }
+            profileCacheByName.remove(existing.name.lowercase())
+            val updated = existing.copy(name = newName)
+            profileCacheById[profileId] = updated
+            profileCacheByName[newName.lowercase()] = updated
+            true
+        } catch (e: Exception) {
+            warn { "同步 Profile $profileId 名称失败: ${e.message}" }
             false
         }
     }

--- a/velocity/src/main/kotlin/icu/h2l/login/inject/network/netty/replacer/LoginProfilePacketReplacer.kt
+++ b/velocity/src/main/kotlin/icu/h2l/login/inject/network/netty/replacer/LoginProfilePacketReplacer.kt
@@ -21,7 +21,6 @@
 
 package icu.h2l.login.inject.network.netty.replacer
 
-import com.velocitypowered.api.network.ProtocolVersion
 import com.velocitypowered.api.proxy.Player
 import com.velocitypowered.api.proxy.ServerConnection
 import com.velocitypowered.api.util.GameProfile
@@ -142,11 +141,13 @@ class LoginProfilePacketReplacer(
     }
 
     private fun genServerLogin(): ServerLoginPacket {
-        return if (player.identifiedKey == null && player.protocolVersion.noLessThan(ProtocolVersion.MINECRAFT_1_19_3)) {
-            ServerLoginPacket(replacedProfile.name, replacedProfile.id)
-        } else {
-            ServerLoginPacket(replacedProfile.name, player.identifiedKey)
-        }
+        // 统一使用 (String, UUID) 构造器确保 holderUuid 非 null。
+        // 高版本协议（≥1.20.2，含 26.x / 1.21.x）encode 时会无条件 writeUuid(holderUuid)，
+        // 若使用 (String, IdentifiedKey) 构造器则 holderUuid 为 null，导致 NPE 无法进入服务器。
+        // playerKey 通过 setPlayerKey 补充设置，兼容 1.19-1.19.2 的 IdentifiedKey 序列化。
+        val packet = ServerLoginPacket(replacedProfile.name, replacedProfile.id)
+        player.identifiedKey?.let { packet.setPlayerKey(it) }
+        return packet
     }
 
     /**

--- a/velocity/src/main/kotlin/icu/h2l/login/profile/VelocityHyperZoneProfileService.kt
+++ b/velocity/src/main/kotlin/icu/h2l/login/profile/VelocityHyperZoneProfileService.kt
@@ -262,5 +262,16 @@ class VelocityHyperZoneProfileService(
         val remapPrefix = HyperZoneLoginMain.getCoreConfig().remap.prefix
         return uuid ?: RemapUtils.genUUID(userName, remapPrefix)
     }
+
+    override fun syncProfileName(profileId: UUID, authenticatedName: String): Boolean {
+        val existing = databaseHelper.getProfile(profileId) ?: return false
+        if (existing.name == authenticatedName) {
+            return true
+        }
+        debug(HyperZoneDebugType.OUTPRE_TRACE) {
+            "profileService.syncProfileName profileId=$profileId oldName=${existing.name} newName=$authenticatedName"
+        }
+        return databaseHelper.updateProfileName(profileId, authenticatedName)
+    }
 }
 

--- a/velocity/src/main/kotlin/icu/h2l/login/vServer/outpre/OutPreBackendBridge.kt
+++ b/velocity/src/main/kotlin/icu/h2l/login/vServer/outpre/OutPreBackendBridge.kt
@@ -178,11 +178,11 @@ class OutPreBackendBridge(
         connection.delayedWrite(handshake)
         connection.protocolVersion = protocolVersion
         connection.setActiveSessionHandler(StateRegistry.LOGIN)
-        if (player.identifiedKey == null && player.protocolVersion.noLessThan(ProtocolVersion.MINECRAFT_1_19_3)) {
-            connection.delayedWrite(ServerLoginPacket(player.username, player.uniqueId))
-        } else {
-            connection.delayedWrite(ServerLoginPacket(player.username, player.identifiedKey))
-        }
+        // 统一使用 (String, UUID) 构造器确保 holderUuid 非 null（≥1.20.2 / 26.x / 1.21.x 兼容），
+        // playerKey 通过 setPlayerKey 补充，兼容 1.19-1.19.2 的 IdentifiedKey 序列化。
+        val loginPacket = ServerLoginPacket(player.username, player.uniqueId)
+        player.identifiedKey?.let { loginPacket.setPlayerKey(it) }
+        connection.delayedWrite(loginPacket)
         connection.flush()
     }
 


### PR DESCRIPTION
thanks LingLeng

## 变更说明

本次修复了如下内容
客户端版本26.x会出现的登录报错与login相关的问题 （这个来自我服务器的玩家）
正版玩家与其他yggd玩家可看到的皮肤数量不一致 #29 
解决了改名不同步的问题 #23 

## 关联范围

- [ ] `openvc`
- [X] `auth-yggd`
- [ ] `auth-offline`
- [ ] `data-merge`
- [X] `profile-skin`
- [X] `api`
- [ ] 文档
- [ ] GitHub 工作流 / 仓库配置

## 变更类型

- [X] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档更新
- [ ] 构建 / CI 调整
- [ ] 其他

## 测试与验证

请说明你做了哪些验证，例如：

- [X] 已本地构建通过
- [X] 已运行相关测试
- [ ] 已验证配置生成 / 加载正常
- [ ] 已验证迁移逻辑或命令行为
- [ ] 已更新相关文档
- [X] 直接上生产环境运行是否解决了问题（当紧急更新推送）

## 兼容性与风险

请说明这次改动是否影响：

- 以修复bug为主

## 其他补充

如有截图、日志、配置示例或后续 TODO，请在此补充。

